### PR TITLE
chore(*) change library name and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # resty-redis-cluster
 Openresty lua client for redis cluster.
 
+### Description
+
+This fork of [steve0511/resty-redis-cluster](https://github.com/steve0511/resty-redis-cluster) includes a few bugfixes and improvements.
+
 ### Why we build this client?
 Openresty has no official client which can support redis cluster. (We could see discussion at https://github.com/openresty/lua-resty-redis/issues/43). Also, looking around other 3rd party openresty redis cluster client , we do't find one can completely support redis cluster features as our project requirement.
 

--- a/kong-redis-cluster-1.1-0.rockspec
+++ b/kong-redis-cluster-1.1-0.rockspec
@@ -1,7 +1,8 @@
-package = "resty-redis-cluster"
-version = "1.0-1"
+package = "kong-redis-cluster"
+version = "1.1-0"
 source = {
-    url = "https://github.com/steve0511/resty-redis-cluster/"
+    url = "https://github.com/Kong/resty-redis-cluster",
+    tag = "1.1-0"
 }
 description = {
     summary = "Openresty lua client for redis cluster",
@@ -10,16 +11,17 @@ description = {
         This is a wrapper around the 'resty.redis' library with cluster discovery 
         and failover recovery support.
     ]],
+    homepage = "https://github.com/Kong/resty-redis-cluster",
     license = "Apache License 2.0"
 }
 dependencies = {
   "lua >= 5.1",
-  "lua-resty-redis",
+  "lua-resty-redis"
 }
 build = {
     type = "builtin",
     modules = {
         ["resty.rediscluster"] = "lib/resty/rediscluster.lua",
-        ["resty.xmodem"] = "lib/resty/xmodem.lua",
+        ["resty.xmodem"] = "lib/resty/xmodem.lua"
     }
 }


### PR DESCRIPTION
## Summary

Renamed library and bumped up the version.

### Changelog

- change library name to kong-redis-cluster
- bump version to 1.1-0
- add description in readme file