### PR TITLE
fix(rediscluster) add error message to return statement

### DIFF
--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -449,7 +449,7 @@ end
 function _M.commit_pipeline(self)
     local _reqs = rawget(self, "_reqs")
 
-    if not _reqs or #_reqs == 0 then return
+    if not _reqs or #_reqs == 0 then return nil, "no pipeline"
     end
 
     self._reqs = nil


### PR DESCRIPTION
## Summary

Added error message in return statement for `commit_pipeline` when there are no requests to commit in the pipeline.

### Changelog

- add error message in return statement for `commit_pipeline` function. The idea brought from (https://github.com/openresty/lua-resty-redis/blob/734abe1d4ecc02d0efb2751bfd9f9a9dddc69719/lib/resty/redis.lua#L363)