### PR TITLE
Merging https://github.com/steve0511/resty-redis-cluster changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Thumbs.db
 
 #c
 *.so
+*.o

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,3 @@ logs/
 # system ignore
 .DS_Store
 Thumbs.db
-
-#c
-*.so
-*.o

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ While building the client, thanks for https://github.com/cuiweixie/lua-resty-red
 
 11. Also verified working properly in AWS elasticache.
 
+12. Allows rolling replacement of redis cluster.
+    Example) Redis Cluster with IPs 10.0.0.2, .3 and .4 is present. New nodes are introduced at IPs 10.0.0.5, .6 and .7. Slots are relocated fom node .2, .3 and .4 to .5, .6, and .7. The initial nodes can now be removed without downtime in nginx, since the initial configuration is not used anymore.
+
 ### installation
 
 1. please add rediscluster.lua and xmodemx.lua at lualib, Also please add library:lua-resty-redis and lua-resty-lock


### PR DESCRIPTION
I was looking to use this library by kong, originally added from [LuaRocks](https://luarocks.org/modules/kong/kong-redis-cluster). The library didn't have a bunch of nil checks and some other changes that [steve0511](https://github.com/steve0511) fixed. I have merged those changes into this PR, so development can continue on this repository for any future updates. I've also used the xmodem implementation that was originally present, so no extra dependencies of build-essentials are required. 