### PR TITLE
chore(rockspec) remove resty redis dependency

### DIFF
--- a/kong-redis-cluster-1.3.0-0.rockspec
+++ b/kong-redis-cluster-1.3.0-0.rockspec
@@ -18,7 +18,6 @@ description = {
 
 dependencies = {
   "lua >= 5.1",
-  "lua-resty-redis"
 }
 
 build = {


### PR DESCRIPTION
The presence of this dependency causes an outdated version of lua-resty-redis to be installed from luarocks:

https://luarocks.org/modules/rafatio/lua-resty-redis

lua-resty-redis is bundled with OpenResty, and this library already [implicitly] depends on OpenResty, so the dependency does not need to be explicitly claimed in our rockspec file.