### PR TITLE
fix: handle the result of redis connect when enable auth

### DIFF
--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -720,9 +720,9 @@ function _M.commit_pipeline(self)
         redis_client:set_timeouts(config.connect_timeout or DEFAULT_CONNECTION_TIMEOUT,
                                   config.send_timeout or DEFAULT_SEND_TIMEOUT,
                                   config.read_timeout or DEFAULT_READ_TIMEOUT)
-        local ok, connerr = redis_client:connect(ip, port, self.config.connect_opts)
+        local ok, err = redis_client:connect(ip, port, self.config.connect_opts)
         if not ok then
-            return nil, "failed to connect, err: " .. connerr
+            return nil, "failed to connect, err: " .. err
         end
 
         local _, autherr = check_auth(self, redis_client)

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -720,7 +720,10 @@ function _M.commit_pipeline(self)
         redis_client:set_timeouts(config.connect_timeout or DEFAULT_CONNECTION_TIMEOUT,
                                   config.send_timeout or DEFAULT_SEND_TIMEOUT,
                                   config.read_timeout or DEFAULT_READ_TIMEOUT)
-        local ok, err = redis_client:connect(ip, port, self.config.connect_opts)
+        local ok, connerr = redis_client:connect(ip, port, self.config.connect_opts)
+        if not ok then
+            return nil, "failed to connect, err: " .. connerr
+        end
 
         local _, autherr = check_auth(self, redis_client)
         if autherr then

--- a/t/connect.t
+++ b/t/connect.t
@@ -1,0 +1,143 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * (3 * blocks());
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_package_cpath "/usr/local/openresty-debug/lualib/?.so;/usr/local/openresty/lualib/?.so;;";
+    lua_shared_dict redis_cluster_slot_locks 100k;
+};
+
+
+no_long_string();
+#no_diff();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: concurrent connections exceed the backlog limit(with auth)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+
+            local config = {
+                            name = "testCluster",                   --rediscluster name
+                            serv_list = {                           --redis cluster node list(host and port),
+                                            { ip = "127.0.0.1", port = 6371 },
+                                            { ip = "127.0.0.1", port = 6372 },
+                                            { ip = "127.0.0.1", port = 6373 },
+                                            { ip = "127.0.0.1", port = 6374 },
+                                            { ip = "127.0.0.1", port = 6375 },
+                                            { ip = "127.0.0.1", port = 6376 }
+                                        },
+                            connect_opts = {
+                                                backlog = 1,
+                                                pool_size = 1,
+                                            },
+                            username = "kong",
+                            password = "kong",
+
+            }
+
+            local t = {}
+            for i = 1, 6 do
+                local th = assert(ngx.thread.spawn(function(i)
+                    local redis = require "resty.rediscluster"
+                    local red, err = redis:new(config)
+
+                    if err then
+                        ngx.say("failed to create redis cluster client: ", err)
+                        return
+                    end
+
+                    red:init_pipeline()
+                    red:hgetall("animals")
+
+                    local res, err = red:commit_pipeline()
+                    if err then
+                        ngx.say(err)
+                        return
+                    end
+                end, i))
+                table.insert(t, th)
+            end
+            for i, th in ipairs(t) do
+                ngx.thread.wait(th)
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body eval
+qr/failed to connect, err: too many waiting connect operations/
+--- no_error_log
+[error]
+
+=== TEST 2: connections in the backlog queue have reached timeout(with auth)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+
+            local config = {
+                            name = "testCluster",                   --rediscluster name
+                            serv_list = {                           --redis cluster node list(host and port),
+                                            { ip = "127.0.0.1", port = 6371 },
+                                            { ip = "127.0.0.1", port = 6372 },
+                                            { ip = "127.0.0.1", port = 6373 },
+                                            { ip = "127.0.0.1", port = 6374 },
+                                            { ip = "127.0.0.1", port = 6375 },
+                                            { ip = "127.0.0.1", port = 6376 }
+                                        },
+                            connect_timeout = 50,
+                            connect_opts = {
+                                                backlog = 100,
+                                                pool_size = 1,
+                                            },
+                            username = "kong",
+                            password = "kong",
+
+            }
+
+            local t = {}
+            for i = 1, 100 do
+                local th = assert(ngx.thread.spawn(function(i)
+                    local redis = require "resty.rediscluster"
+                    local red, err = redis:new(config)
+
+                    if err then
+                        ngx.say("failed to create redis cluster client: ", err)
+                        return
+                    end
+
+                    red:init_pipeline()
+                    red:hmset("animals", { dog = "bark", cat = "meow", cow = "moo" })
+
+                    local res, err = red:commit_pipeline()
+                    if err then
+                        ngx.say(err)
+                        return
+                    end
+                end, i))
+                table.insert(t, th)
+            end
+            for i, th in ipairs(t) do
+                ngx.thread.wait(th)
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body eval
+qr/failed to connect, err: timeout/
+--- error_log eval
+qr/lua tcp socket queued connect timed out/


### PR DESCRIPTION
relates to [FTI-5199](https://konghq.atlassian.net/browse/FTI-5199)

here explain why we need this fix: [5199-rate-limiting-advanced](https://konghq.atlassian.net/wiki/spaces/TS/pages/3169812508/5199-rate-limiting-advanced)

run test cases on my local success
<img width="1752" alt="Untitled" src="https://github.com/Kong/resty-redis-cluster/assets/131840510/7b99b65a-92a0-4fd8-b869-51416053fd57">
<img width="1768" alt="sta" src="https://github.com/Kong/resty-redis-cluster/assets/131840510/f6aaa2a9-82f8-41a2-9d53-c27934a275ee">


[FTI-5199]: https://konghq.atlassian.net/browse/FTI-5199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ