### PR TITLE
fix(auth): allow username set to "default"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-OPENRESTY_PREFIX ?=/usr/local/openresty
-PREFIX ?=          /usr/local
-LUA_INCLUDE_DIR ?= $(PREFIX)/include
-LUA_LIB_DIR ?=     $(PREFIX)/lib/lua/$(LUA_VERSION)
-INSTALL ?= install
+LUA_VERSION      ?= 5.1
+OPENRESTY_PREFIX ?= /usr/local/openresty
+PREFIX           ?= /usr/local
+LUA_INCLUDE_DIR  ?= $(PREFIX)/include
+LUA_LIB_DIR      ?= $(PREFIX)/lib/lua/$(LUA_VERSION)
+INSTALL          ?= install
 
 .PHONY: all test install
 

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -63,6 +63,7 @@ local function redis_slot(str)
 end
 
 local function check_auth(self, redis_client)
+    -- redis before 6.0
     if type(self.config.auth) == "string" then
         local count, err = redis_client:get_reused_times()
         if not count then
@@ -81,11 +82,7 @@ local function check_auth(self, redis_client)
             return true, nil -- reusing the connection, so already authenticated
         end
 
-        if self.config.username then
-            if self.config.username == "default" then
-                -- redis uses 'default' as the default username now for the pre-6 scheme
-                return nil, "'username' cannot be 'default'"
-            end
+        if type(self.config.username) == "string" then
             return redis_client:auth(self.config.username, self.config.password)
         else
             return redis_client:auth(self.config.password)

--- a/t/auth.t
+++ b/t/auth.t
@@ -1,0 +1,162 @@
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * (3 * blocks());
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_package_cpath "/usr/local/openresty-debug/lualib/?.so;/usr/local/openresty/lualib/?.so;;";
+    lua_shared_dict redis_cluster_slot_locks 32k;
+    init_by_lua '
+        require("luacov")
+    ';
+};
+
+
+no_long_string();
+#no_diff();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: auth
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+
+            local config = {
+                            name = "testCluster",                   --rediscluster name
+                            serv_list = {                           --redis cluster node list(host and port),
+                                            { ip = "127.0.0.1", port = 6381 },
+                                            { ip = "127.0.0.1", port = 6382 },
+                                            { ip = "127.0.0.1", port = 6383 },
+                                            { ip = "127.0.0.1", port = 6384 },
+                                            { ip = "127.0.0.1", port = 6385 },
+                                            { ip = "127.0.0.1", port = 6386 },
+                                            { ip = "127.0.0.1", port = 6387 }
+                                        },
+                            keepalive_timeout = 60000,              --redis connection pool idle timeout
+                            keepalive_cons = 1000,                  --redis connection pool size
+                            connect_timeout = 1000,                 --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
+                            max_redirection = 5,                    --maximum retry attempts for redirection
+                            auth = "kong",
+
+            }
+            local redis = require "resty.rediscluster"
+            local red, err = redis:new(config)
+
+            if err then
+                ngx.say("failed to create: ", err)
+                return
+            end
+
+
+            local res, err = red:set("dog", "an animal")
+            if not res then
+                ngx.say("failed to set dog: ", err)
+                return
+            end
+
+            ngx.say("set dog: ", res)
+
+            for i = 1, 2 do
+                local res, err = red:get("dog")
+                if err then
+                    ngx.say("failed to get dog: ", err)
+                    return
+                end
+
+                if not res then
+                    ngx.say("dog not found.")
+                    return
+                end
+
+                ngx.say("dog: ", res)
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+set dog: OK
+dog: an animal
+dog: an animal
+--- no_error_log
+[error]
+
+=== TEST 2: username and password
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+
+            local config = {
+                            name = "testCluster",                   --rediscluster name
+                            serv_list = {                           --redis cluster node list(host and port),
+                                            { ip = "127.0.0.1", port = 6381 },
+                                            { ip = "127.0.0.1", port = 6382 },
+                                            { ip = "127.0.0.1", port = 6383 },
+                                            { ip = "127.0.0.1", port = 6384 },
+                                            { ip = "127.0.0.1", port = 6385 },
+                                            { ip = "127.0.0.1", port = 6386 },
+                                            { ip = "127.0.0.1", port = 6387 }
+                                        },
+                            keepalive_timeout = 60000,              --redis connection pool idle timeout
+                            keepalive_cons = 1000,                  --redis connection pool size
+                            connect_timeout = 1000,                 --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
+                            max_redirection = 5,                    --maximum retry attempts for redirection
+                            username = "default",
+                            password = "kong",
+
+            }
+            local redis = require "resty.rediscluster"
+            local red, err = redis:new(config)
+
+            if err then
+                ngx.say("failed to create: ", err)
+                return
+            end
+
+
+            local res, err = red:set("dog", "an animal")
+            if not res then
+                ngx.say("failed to set dog: ", err)
+                return
+            end
+
+            ngx.say("set dog: ", res)
+
+            for i = 1, 2 do
+                local res, err = red:get("dog")
+                if err then
+                    ngx.say("failed to get dog: ", err)
+                    return
+                end
+
+                if not res then
+                    ngx.say("dog not found.")
+                    return
+                end
+
+                ngx.say("dog: ", res)
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+set dog: OK
+dog: an animal
+dog: an animal
+--- no_error_log
+[error]


### PR DESCRIPTION
To be compatible with Redis before `6.0`, supporting ACL with `default` username.

Local test results:

![image](https://github.com/Kong/resty-redis-cluster/assets/6426329/9bac5451-443b-40a6-9b2c-e27a906004d6)


```bash
ubuntu@ip-172-31-9-194:~/workspace/resty-redis-cluster$ PATH="/usr/local/openresty/nginx/sbin:$PATH" prove -v t/auth.t
t/auth.t ..
1..12
ok 1 - t/auth.t TEST 2: username and password - status code ok
ok 2 - t/auth.t TEST 2: username and password - response_body - response is expected (repeated req 0, req 0)
ok 3 - t/auth.t TEST 2: username and password - pattern "[error]" does not match a line in error.log (req 0)
ok 4 - t/auth.t TEST 2: username and password - status code ok
ok 5 - t/auth.t TEST 2: username and password - response_body - response is expected (repeated req 1, req 0)
ok 6 - t/auth.t TEST 2: username and password - pattern "[error]" does not match a line in error.log (req 1)
ok 7 - t/auth.t TEST 1: auth - status code ok
ok 8 - t/auth.t TEST 1: auth - response_body - response is expected (repeated req 0, req 0)
ok 9 - t/auth.t TEST 1: auth - pattern "[error]" does not match a line in error.log (req 0)
ok 10 - t/auth.t TEST 1: auth - status code ok
ok 11 - t/auth.t TEST 1: auth - response_body - response is expected (repeated req 1, req 0)
ok 12 - t/auth.t TEST 1: auth - pattern "[error]" does not match a line in error.log (req 1)
ok
All tests successful.
Files=1, Tests=12,  1 wallclock secs ( 0.02 usr  0.00 sys +  0.14 cusr  0.02 csys =  0.18 CPU)
Result: PASS
```