### PR TITLE
fix: avoid linear growth of `serv_list_combined`

### DIFF
--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -230,7 +230,13 @@ function _M.fetch_slots(self)
 
     -- if a cached serv_list is present, start with that
     if serv_list_cached then
-        serv_list_combined = serv_list_cached.serv_list
+        if not serv_list_combined then
+            serv_list_combined = {}
+        end
+
+        for i, s in ipairs(serv_list_cached.serv_list) do
+            table_insert(serv_list_combined, i, s)
+        end
 
         -- then prepend the serv_list from config, in the event that the entire
         -- config serv_list no longer points to anything usable, try the cached IPs
@@ -242,6 +248,7 @@ function _M.fetch_slots(self)
         serv_list_combined = serv_list
     end
 
+    ngx.log(ngx.DEBUG, "fetching slots from: ", #serv_list_combined, " servers")
     -- important!
     serv_list_cached = nil -- luacheck: ignore
 

--- a/t/mock-redis-down.t
+++ b/t/mock-redis-down.t
@@ -1,0 +1,105 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * (6 * blocks());
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_package_cpath "/usr/local/openresty-debug/lualib/?.so;/usr/local/openresty/lualib/?.so;;";
+    lua_shared_dict redis_cluster_slot_locks 32k;
+
+    init_by_lua_block {
+        require "resty.core"
+        local redis = require "resty.redis"
+        local origin_redis_connect_fn = redis.connect
+        redis.connect = function(...)
+            local args = {...}
+            if not args[4] then
+                return nil, "mock redis connect error"
+            end
+
+            local red = origin_redis_connect_fn(...)
+            return red
+        end
+    }
+};
+
+no_long_string();
+#no_diff();
+
+
+run_tests();
+
+__DATA__
+
+=== TEST 15: fetch_slots
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local config = {
+                            name = "testCluster",                   --rediscluster name
+                            serv_list = {                           --redis cluster node list(host and port),
+                                            { ip = "127.0.0.1", port = 6371 },
+                                            { ip = "127.0.0.1", port = 6372 },
+                                            { ip = "127.0.0.1", port = 6373 },
+                                            { ip = "127.0.0.1", port = 6374 },
+                                            { ip = "127.0.0.1", port = 6375 },
+                                            { ip = "127.0.0.1", port = 6376 }
+                                        },
+                            keepalive_timeout = 60000,              --redis connection pool idle timeout
+                            keepalive_cons = 1000,                  --redis connection pool size
+                            connect_timeout = 1000,               --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
+                            max_redirection = 5,                    --maximum retry attempts for redirection
+                            connect_opts = {
+                                                backlog = 30,
+                                                pool_size = 30,
+                                                ssl = false,
+                                                ssl_verify = false,
+                                            },
+
+            }
+
+            local redis = require "resty.rediscluster"
+            local red, err = redis:new(config)
+
+            if not red then
+                ngx.say("failed to instantiate redis: ", err)
+                return
+            end
+
+            local res, err = red:set("foo", "bar")
+            if not res then
+                ngx.say("failed to set foo: ", err)
+                return
+            end
+
+            -- mock redis connect error
+            red.config.connect_opts = nil
+
+            local res, err = red:get("foo")
+            if not res then
+                ngx.say("failed to get foo: ", err)
+                return
+            end
+            ngx.say("get foo: ", res)
+        ';
+    }
+--- request
+GET /t
+--- no_error_log eval
+[qr/fetching slots from: 18 servers/,
+qr/fetching slots from: 24 servers/,
+qr/fetching slots from: 30 servers/,
+qr/fetching slots from: 36 servers/]
+--- response_body
+failed to get foo: mock redis connect error
+--- wait: 1


### PR DESCRIPTION
In a scenario where the redis server is down,
the `serv_list_combined` in the `fetch_slots` function 
grows linearly because the `serv_list_combined`
actually points to a module-level table to which
each `fetch_slots` writes duplicates of the
`self.config.serv_list` data.

Fix: [FTI-5593](https://konghq.atlassian.net/browse/FTI-5593)