### PR TITLE
fix: parse cluster hash tags following the Redis specifications

### DIFF
--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -29,28 +29,34 @@ local DEFAULT_CONNECTION_TIMEOUT = 1000
 local DEFAULT_SEND_TIMEOUT = 1000
 local DEFAULT_READ_TIMEOUT = 1000
 
--- According to the Redis documentation, the hash tag is found only if the '{' and '}'
--- are exist in the key, or it should use the whole key to calculate the slot.
--- See: redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags.
---
--- For the Redis hash slot implemetation, see: https://github.com/redis/redis/blob/8a05f0092b0e291498b8fdb8dd93355467ceab25/src/cluster.c#L30-L49
-local function parse_key(key_str)
-    local left_tag_single_index = string_find(key_str, "{", 1)
-    if not left_tag_single_index then
-        return key_str
-    end
-
-    local right_tag_single_index = string_find(key_str, "}", left_tag_single_index + 1)
-    if right_tag_single_index and right_tag_single_index > left_tag_single_index + 1 then
-        return key_str.sub(key_str, left_tag_single_index + 1, right_tag_single_index - 1)
-    end
-    return key_str
-end
-
+local LEFT_BRACKET = "{"
+local RIGHT_BRACKET = "}"
 
 local _M = {}
 
 local mt = { __index = _M }
+
+
+-- According to the Redis documentation, the hash tag is found only if the '{' and '}'
+-- are exist in the key, or it should use the whole key to calculate the slot.
+-- See: https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags
+--
+-- For the Redis hash slot implemetation, see: https://github.com/redis/redis/blob/8a05f0092b0e291498b8fdb8dd93355467ceab25/src/cluster.c#L30-L49
+local function parse_key(key_str)
+    local left_index = string_find(key_str, LEFT_BRACKET, 1, true)
+    if not left_index then
+        return key_str
+    end
+
+    local right_index = string_find(key_str, RIGHT_BRACKET, left_index + 1, true)
+    if right_index and right_index > left_index + 1 then
+        return key_str:sub(left_index + 1, right_index - 1)
+    end
+    return key_str
+end
+-- export for testing
+_M.parse_key = parse_key
+
 
 local slot_cache = {}
 local master_nodes = {}
@@ -794,7 +800,7 @@ function _M.cancel_pipeline(self)
     self._reqs = nil
 end
 
-_M.parse_key = parse_key
+
 local function _do_eval_cmd(self, cmd, ...)
 --[[
 eval command usage:

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -29,6 +29,11 @@ local DEFAULT_CONNECTION_TIMEOUT = 1000
 local DEFAULT_SEND_TIMEOUT = 1000
 local DEFAULT_READ_TIMEOUT = 1000
 
+-- According to the Redis documentation, the hash tag is found only if the '{' and '}'
+-- are exist in the key, or it should use the whole key to calculate the slot.
+-- See: redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags.
+--
+-- For the Redis hash slot implemetation, see: https://github.com/redis/redis/blob/8a05f0092b0e291498b8fdb8dd93355467ceab25/src/cluster.c#L30-L49
 local function parse_key(key_str)
     local left_tag_single_index = string_find(key_str, "{", 1)
     if not left_tag_single_index then
@@ -37,7 +42,6 @@ local function parse_key(key_str)
 
     local right_tag_single_index = string_find(key_str, "}", left_tag_single_index + 1)
     if right_tag_single_index then
-        --parse hashtag
         return key_str.sub(key_str, left_tag_single_index + 1, right_tag_single_index - 1)
     end
     return key_str
@@ -790,7 +794,7 @@ function _M.cancel_pipeline(self)
     self._reqs = nil
 end
 
-function _M.parse_key = parse_key
+_M.parse_key = parse_key
 local function _do_eval_cmd(self, cmd, ...)
 --[[
 eval command usage:

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -790,6 +790,9 @@ function _M.cancel_pipeline(self)
     self._reqs = nil
 end
 
+function _M.parse_key(_, key)
+    return parse_key(key)
+end
 local function _do_eval_cmd(self, cmd, ...)
 --[[
 eval command usage:

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -41,7 +41,7 @@ local function parse_key(key_str)
     end
 
     local right_tag_single_index = string_find(key_str, "}", left_tag_single_index + 1)
-    if right_tag_single_index then
+    if right_tag_single_index and right_tag_single_index > left_tag_single_index + 1 then
         return key_str.sub(key_str, left_tag_single_index + 1, right_tag_single_index - 1)
     end
     return key_str

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -30,14 +30,17 @@ local DEFAULT_SEND_TIMEOUT = 1000
 local DEFAULT_READ_TIMEOUT = 1000
 
 local function parse_key(key_str)
-    local left_tag_single_index = string_find(key_str, "{", 0)
-    local right_tag_single_index = string_find(key_str, "}", 0)
-    if left_tag_single_index and right_tag_single_index then
-        --parse hashtag
-        return key_str.sub(key_str, left_tag_single_index + 1, right_tag_single_index - 1)
-    else
+    local left_tag_single_index = string_find(key_str, "{", 1)
+    if not left_tag_single_index then
         return key_str
     end
+
+    local right_tag_single_index = string_find(key_str, "}", left_tag_single_index + 1)
+    if right_tag_single_index then
+        --parse hashtag
+        return key_str.sub(key_str, left_tag_single_index + 1, right_tag_single_index - 1)
+    end
+    return key_str
 end
 
 

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -790,9 +790,7 @@ function _M.cancel_pipeline(self)
     self._reqs = nil
 end
 
-function _M.parse_key(_, key)
-    return parse_key(key)
-end
+function _M.parse_key = parse_key
 local function _do_eval_cmd(self, cmd, ...)
 --[[
 eval command usage:

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1039,42 +1039,11 @@ cow: moo
     location /t {
         content_by_lua '
 
-            local config = {
-                            name = "testCluster",                   --rediscluster name
-                            serv_list = {                           --redis cluster node list(host and port),
-                                            { ip = "127.0.0.1", port = 6371 },
-                                            { ip = "127.0.0.1", port = 6372 },
-                                            { ip = "127.0.0.1", port = 6373 },
-                                            { ip = "127.0.0.1", port = 6374 },
-                                            { ip = "127.0.0.1", port = 6375 },
-                                            { ip = "127.0.0.1", port = 6376 }
-                                        },
-                            keepalive_timeout = 60000,              --redis connection pool idle timeout
-                            keepalive_cons = 1000,                  --redis connection pool size
-                            connect_timeout = 1000,               --timeout while connecting
-                            read_timeout = 1000,                    --timeout while reading
-                            send_timeout = 1000,                    --timeout while sending
-                            max_redirection = 5,                    --maximum retry attempts for redirection
-                            connect_opts = {
-                                                backlog = 30,
-                                                pool_size = 30,
-                                                ssl = false,
-                                                ssl_verify = false,
-                                            },
-
-            }
-
             local redis = require "resty.rediscluster";
-            local red, err = redis:new(config);
-
-            if err then
-                ngx.say("failed to create: ", err);
-                return
-            end
 
             local keys = {"foo{bar}hi", "foo}bar{hello", "foobar"};
             for _, key in ipairs(keys) do
-                ngx.say("parsed_key: ", red:parse_key(key));
+                ngx.say("parsed_key: ", redis.parse_key(key));
             end
         ';
     }

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1032,3 +1032,57 @@ cat: meow
 cow: moo
 --- no_error_log
 [error]
+
+=== TEST 15: parse key should work well
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+
+            local config = {
+                            name = "testCluster",                   --rediscluster name
+                            serv_list = {                           --redis cluster node list(host and port),
+                                            { ip = "127.0.0.1", port = 6371 },
+                                            { ip = "127.0.0.1", port = 6372 },
+                                            { ip = "127.0.0.1", port = 6373 },
+                                            { ip = "127.0.0.1", port = 6374 },
+                                            { ip = "127.0.0.1", port = 6375 },
+                                            { ip = "127.0.0.1", port = 6376 }
+                                        },
+                            keepalive_timeout = 60000,              --redis connection pool idle timeout
+                            keepalive_cons = 1000,                  --redis connection pool size
+                            connect_timeout = 1000,               --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
+                            max_redirection = 5,                    --maximum retry attempts for redirection
+                            connect_opts = {
+                                                backlog = 30,
+                                                pool_size = 30,
+                                                ssl = false,
+                                                ssl_verify = false,
+                                            },
+
+            }
+
+            local redis = require "resty.rediscluster";
+            local red, err = redis:new(config);
+
+            if err then
+                ngx.say("failed to create: ", err);
+                return
+            end
+
+            local keys = {"foo{bar}hi", "foo}bar{hello", "foobar"};
+            for _, key in ipairs(keys) do
+                ngx.say("parsed_key: ", red:parse_key(key));
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+parsed_key: bar
+parsed_key: foo}bar{hello
+parsed_key: foobar
+--- no_error_log
+[error]

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1043,7 +1043,7 @@ cow: moo
 
             local redis = require "resty.rediscluster";
 
-            local keys = {"foo{bar}hi", "foo}bar{hello", "foobar"};
+            local keys = {"{foobar}", "foo{bar}hi", "foo}bar{hello", "foobar", "foo{}{bar}", "foo{{bar}}", "foo{bar}{zap}"};
             for _, key in ipairs(keys) do
                 ngx.say("parsed_key: ", redis.parse_key(key));
             end
@@ -1052,8 +1052,12 @@ cow: moo
 --- request
 GET /t
 --- response_body
+parsed_key: foobar
 parsed_key: bar
 parsed_key: foo}bar{hello
 parsed_key: foobar
+parsed_key: foo{}{bar}
+parsed_key: {bar
+parsed_key: bar
 --- no_error_log
 [error]

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1033,7 +1033,9 @@ cow: moo
 --- no_error_log
 [error]
 
-=== TEST 15: parse key should work well
+
+
+=== TEST 15:  parse cluster hash tags as redis spec
 --- http_config eval: $::HttpConfig
 --- config
     location /t {


### PR DESCRIPTION
Currently, the parse_key function parses the hashtag without checking
if the right position is greater than the left position, so it might retrieve the wrong empty hashtag.

For example, the whole key is expected if the key is 'A}B{C' but it will get an empty string,
and it might be redirected to the wrong slot number.

Also, it's unnecessary to find the right tag index if the left index is not found.