### PR TITLE
feat(lock): add lock_timeout option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Currently, this library is fully tested with Redis `6.x` and `7.x`.
 
    This is a breaking change when there is network issues and the clients
    tries to refresh the slot info. Before the fix, all clients will refresh
-   once, and after the fix only one client is fixing it.
+   once, and after the fix only one client is refreshing it.
 3. Return detailed error message to downstream component (e.g. Kong Gateway)
    for better debuggability.
 

--- a/t/connect.t
+++ b/t/connect.t
@@ -82,8 +82,8 @@ __DATA__
 GET /t
 --- response_body eval
 qr/failed to connect, err: [1-9][0-9.:]+ too many waiting connect operations/
---- no_error_log
-[error]
+--- error_log
+failed to acquire the lock in refreshing slot cache: timeout
 
 
 

--- a/t/lock_timeout.t
+++ b/t/lock_timeout.t
@@ -1,0 +1,93 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+my $redis_auth = $ENV{REDIS_AUTH};
+if (defined($redis_auth) && $redis_auth eq "no") {
+    plan tests => repeat_each() * (5 * blocks());
+} else {
+    plan(skip_all => "skip when REDIS_AUTH is enabled");
+}
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_package_cpath "/usr/local/openresty-debug/lualib/?.so;/usr/local/openresty/lualib/?.so;;";
+    lua_shared_dict redis_cluster_slot_locks 32k;
+};
+
+
+no_long_string();
+#no_diff();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: return detailed error message
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+
+            local config = {
+                            name = "testCluster",                   -- rediscluster name
+                            serv_list = {                           -- redis cluster node list(host and port), invalid address
+                                            { ip = "10.255.255.100", port = 6371 },
+                                        },
+                            keepalive_timeout = 60000,              -- redis connection pool idle timeout
+                            keepalive_cons = 1000,                  -- redis connection pool size
+                            connect_timeout = 1000,                 -- timeout while connecting
+                            read_timeout = 1000,                    -- timeout while reading
+                            send_timeout = 1000,                    -- timeout while sending
+                            lock_timeout = 0,                       -- timeout while acquiring resty.lock
+                            max_redirection = 5                     -- maximum retry attempts for redirection
+
+            }
+
+            local rc = require "resty.rediscluster"
+            local spawn = ngx.thread.spawn
+            local wait = ngx.thread.wait
+            local say = ngx.say
+
+            local function initialize(i)
+              local red, err = rc:new(config)
+
+              if err then
+                return i .. ":" .. err
+              end
+
+              return "ok"
+            end
+
+            local num = 3
+            local threads = {}
+            for i = 1, num do
+              table.insert(threads, spawn(initialize, i))
+            end
+            for i = 1, num do
+              local tok, res = wait(threads[i])
+
+              if not tok then
+                say("failed to run thread ", i)
+
+              else
+                say(res)
+              end
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+1:failed to fetch slots: timeout;timeout;timeout
+2:failed to acquire the lock in initializing slot cache: timeout
+3:failed to acquire the lock in initializing slot cache: timeout
+--- error_log
+unable to connect ip:port 10.255.255.100:6371, attempt 1
+unable to connect ip:port 10.255.255.100:6371, attempt 2
+unable to connect ip:port 10.255.255.100:6371, attempt 3


### PR DESCRIPTION
feat(lock): add lock_timeout option

1. Currently, the timeout for acquiring a lock is fixed to `5s`.
We add a new option `lock_timeout` to make it configurable.
2. The lock timeout parameter was incorrectly set to `time_out`.
We fix it to `timeout`.
3. Additionally, return detailed error message to downstream
component (e.g. Kong Gateway).


FTI-6329