### PR TITLE
chore(release): bump version from 1.5.4 to 1.5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ Currently, this library is fully tested with Redis `6.x` and `7.x`.
 
 #### Unreleased
 
+1. TBD
+
+#### 1.5.5
+
 1. Currently, the timeout for acquiring a lock is fixed to `5s`.
    We add a new option `lock_timeout` to make it configurable.
 2. The lock timeout parameter was incorrectly set to `time_out = 0`.

--- a/kong-redis-cluster-1.5.5-0.rockspec
+++ b/kong-redis-cluster-1.5.5-0.rockspec
@@ -1,8 +1,8 @@
 package = "kong-redis-cluster"
-version = "1.5.4-0"
+version = "1.5.5-0"
 source = {
     url = "git://github.com/Kong/resty-redis-cluster",
-    tag = "1.5.4"
+    tag = "1.5.5"
 }
 
 description = {


### PR DESCRIPTION
chore(release): bump version from 1.5.4 to 1.5.5

FTI-6329
