### PR TITLE
has_moved_signal passed res instead of err causing "MOVED" not to work

### DIFF
--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -843,7 +843,7 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
 
             if err then
                 -- todo: we can follow the moved target instead of refreshing the slots
-                if has_moved_signal(res) then
+                if has_moved_signal(err) then
                     ngx_log(NGX_DEBUG, "find MOVED signal, trigger retry for normal commands, cmd:" .. cmd .. " key:" .. tostring(key))
                     -- if retry with moved, we will not asking to specific ip:port anymore
                     target_ip = nil


### PR DESCRIPTION
because of bad param passed to has_moved_signal, res instead of err in case of MOVED error, the code will throw it as error, and won't try to refresh list of slots, and retry the send as expected. from check i did these are the params we have:
err MOVED 4444 :6379
res false

as you can see, res is just the boolean and not the actual error, err should be used as param to the method.