### PR TITLE
chore(release): bump version from 1.5.6 to 1.5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,10 @@ Currently, this library is fully tested with Redis `6.x` and `7.x`.
 
 1. TBD
 
+#### 1.5.7
+
+1. Add `force_auth` flag to control whether to call `auth` after each `connect`.
+
 #### 1.5.6
 
 1. Set pool name before connect so that connetions won't be reused incorrectly.

--- a/kong-redis-cluster-1.5.7-0.rockspec
+++ b/kong-redis-cluster-1.5.7-0.rockspec
@@ -1,8 +1,8 @@
 package = "kong-redis-cluster"
-version = "1.5.6-0"
+version = "1.5.7-0"
 source = {
     url = "git://github.com/Kong/resty-redis-cluster",
-    tag = "1.5.6"
+    tag = "1.5.7"
 }
 
 description = {


### PR DESCRIPTION
[KAG-7723](https://konghq.atlassian.net/browse/KAG-7723)

Add `force_auth` flag to control whether to call `auth` after each `connect`.


[KAG-7723]: https://konghq.atlassian.net/browse/KAG-7723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ